### PR TITLE
住所データをローカルからも読み込めるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ print(normalize("北海道札幌市西区24-2-2-3-3", level=1))
 # {'pref': '北海道', 'city': '', 'town': '', 'addr': '札幌市西区24-2-2-3-3', 'lat': 43.074273, 'lng': 141.315099, 'level': 1}
 ```
 
+名寄せする住所は、[@geolonia/japanese-addresses](https://geolonia.github.io/japanese-addresses/api/ja)から都度取得しています。
+
+`endpoint` オプションで `file://` 形式のURLを指定することで、ローカルファイルとして保存した住所を参照することができます。
+```
+# Geolonia 住所データのダウンロード
+$ curl -sL https://github.com/geolonia/japanese-addresses/archive/refs/heads/master.tar.gz | tar xvfz -
+```
+※住所データを最新にしたい場合は都度上記コマンドでダウンロードしてください。
+
+```python
+from normalize_japanese_addresses import normalize
+print(normalize("北海道札幌市西区24-2-2-3-3", endpoint="file:///path/to/japanese-addresses-master/api/ja"))
+# {'pref': '北海道', 'city': '札幌市西区', 'town': '二十四軒二条二丁目', 'addr': '3-3', 'lat': 43.074273, 'lng': 141.315099, 'level': 3}
+```
+
+
 ## 注意
 
 以下の仕様は、元の [@geolonia/normalize-japanese-addresses](https://github.com/geolonia/normalize-japanese-addresses)を踏襲しています。  
@@ -45,7 +61,6 @@ print(normalize("北海道札幌市西区24-2-2-3-3", level=1))
   * 郵便や宅急便などに使用される住所としては、問題ないと考えています。
 * この正規化エンジンは、町丁目及び小字レベルまでは対応していますが、それ以降については対応しておりません。
 * 住居表示が未整備の地域については全体的に苦手です。
-* 名寄せする住所は、[@geolonia/japanese-addresses](https://geolonia.github.io/japanese-addresses/api/ja)から都度取得しています。　
 * 漢数字と数字の変換については、[@geolonia/japanese-numeral](https://github.com/geolonia/japanese-numeral)をPythonに書き直して取り込んでいます。
 
 ## ライセンス、利用規約

--- a/normalize_japanese_addresses/library/api.py
+++ b/normalize_japanese_addresses/library/api.py
@@ -1,5 +1,17 @@
+import urllib.parse
+
 import requests
 
 
 def apiFetch(endpoint: str = ''):
-    return requests.get(f'{endpoint}')
+    if endpoint.startswith('http'):
+        return requests.get(f'{endpoint}')
+    elif endpoint.startswith('file'):
+        filepath = urllib.parse.unquote(endpoint.replace("file://", ""))
+        with open(filepath) as fp:
+            # ファイから読み込んだ内容を擬似的にResponseオブジェクトに格納する
+            res = requests.Response()
+            res._content = fp.read().encode("utf-8")
+            return res
+    else:
+        raise ValueError("Invalid endpoint type")

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -19,3 +19,12 @@ def test_normalize_add_0003():
            {"pref": "北海道", "city": "", "town": "", "addr": "札幌市西区24-2-2-3-3",
             "lat": None, "lng": None, "level": 1}
 
+
+# @geolonia/japanese-addresses にある住所データをローカルから読み込むテスト
+# テスト実行用に下記コマンドで /tmp/ 以下に住所データを保存する
+# curl -sL https://github.com/geolonia/japanese-addresses/archive/refs/heads/master.tar.gz | tar xvfz - -C /tmp/
+def test_normalize_add_0004():
+    assert normalize('北海道札幌市西区24-2-2-3-3', level=3, endpoint='file:///tmp/japanese-addresses-master/api/ja') ==            \
+           {"pref": "北海道", "city": "札幌市西区", "town": "二十四軒二条二丁目", "addr": "3-3",
+            "lat": 43.074273, "lng": 141.315099, "level": 3}
+


### PR DESCRIPTION
Web API経由で取得している住所データをローカルのファイルからも読み込めるようにしました。

```
# Geolonia 住所データのダウンロード
$ curl -sL https://github.com/geolonia/japanese-addresses/archive/refs/heads/master.tar.gz | tar xvfz -
```

```python
from normalize_japanese_addresses import normalize
print(normalize("北海道札幌市西区24-2-2-3-3", endpoint="file:///path/to/japanese-addresses-master/api/ja"))
# {'pref': '北海道', 'city': '札幌市西区', 'town': '二十四軒二条二丁目', 'addr': '3-3', 'lat': 43.074273, 'lng': 141.315099, 'level': 3}
```