### PR TITLE
Kanjize 1.3.0 対応

### DIFF
--- a/normalize_japanese_addresses/library/regex.py
+++ b/normalize_japanese_addresses/library/regex.py
@@ -87,7 +87,7 @@ def getTownRegexes(pref: str, city: str, endpoint):
         else:
             num = match_value
             for match in re.finditer('([一二三四五六七八九十]+)', match_value):
-                replace_num = str(kanjize.kanji2int(match.group()))
+                replace_num = str(kan2num(match.group()))
                 num = num.replace(match.group(), replace_num)
 
             num = re.sub('(丁目?|番([町丁])|条|軒|線|([のノ])町|地割)', '', num)
@@ -127,9 +127,11 @@ def getTownRegexes(pref: str, city: str, endpoint):
         originalTown = town['town']
         if str(originalTown).find('町') == -1:
             continue
-        
-        townAddr = re.sub('(?!^町)町', '', originalTown) # NOTE: 冒頭の「町」は明らかに省略するべきではないので、除外
-        
+
+        # 「愛知県名古屋市瑞穂区十六町1丁目」など漢数字を含むケースは、曖昧処理から除外
+        if re.match('[壱一二三四五六七八九十百千万]+町', originalTown) is None:
+            townAddr = re.sub('(?!^町)町', '', originalTown) # NOTE: 冒頭の「町」は明らかに省略するべきではないので、除外
+
         if (
             townAddr not in api_towns_set and
             f'大字{townAddr}' not in api_towns_set and   # 大字は省略されるため、大字〇〇と〇〇町がコンフリクトする。このケースを除外

--- a/normalize_japanese_addresses/library/utils.py
+++ b/normalize_japanese_addresses/library/utils.py
@@ -1,6 +1,6 @@
 import re
 
-from kanjize import kanji2int, int2kanji
+from kanjize import kanji2number, int2kanji
 
 from .japaneseNumerics import japaneseNumerics, oldJapaneseNumerics
 
@@ -21,13 +21,13 @@ def splitLargeNumber(japanese: str):
     for key, value in largeNumbers.items():
         match = re.match(f'(.+){key}', kanji)
         if match is not None:
-            numbers[key] = kanji2int(match.group())
+            numbers[key] = kanji2number(match.group())
             kanji = kanji.replace(match.group(), '')
         else:
             numbers[key] = 0
 
     if len(kanji) > 0:
-        numbers['千'] = kanji2int(kanji)
+        numbers['千'] = kanji2number(kanji)
     else:
         numbers['千'] = 0
 
@@ -36,12 +36,12 @@ def splitLargeNumber(japanese: str):
 
 def kan2num(value: str):
     for fromValue in findKanjiNumbers(value):
-        value = value.replace(fromValue, str(kanji2number(fromValue)))
+        value = value.replace(fromValue, str(_kanji2integer(fromValue)))
 
     return value
 
 
-def kanji2number(japanese: str):
+def _kanji2integer(japanese: str):
     japanese = normalize(japanese)
 
     if re.match('〇', japanese) is not None or re.match('^[〇一二三四五六七八九]+$', japanese) is not None:
@@ -59,7 +59,7 @@ def kanji2number(japanese: str):
                 number = number + n
 
         if not str(number).isdigit() or not str(numbers['千']).isdigit():
-            raise TypeError('The attribute of kanji2number() must be a Japanese numeral as integer.')
+            raise TypeError('The attribute of _kanji2integer() must be a Japanese numeral as integer.')
 
         return number + numbers['千']
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.20.2
-kanjize==1.0.0
-pytest==6.2.3
-requests==2.25.1
-pandas==1.2.4
-cachetools==4.2.2
+numpy==1.24.1
+kanjize==1.3.0
+pytest==7.2.1
+requests==2.28.2
+pandas==1.5.3
+cachetools==5.3.0


### PR DESCRIPTION
利用している Kanjize ライブラリ の 最新版（1.3.0）への対応、および、それに伴う不具合の修正になります。  
  
### 変更点  
- `requirements.txt`に記載されているライブラリ・バージョンを最新版（2023年1月25日時点）に変更  
- kanjize 1.3.0 での `kanji2int` 廃止、および `kanji2number` 導入に対応したコードの修正（主に utils.py）
- 上記仕様変更による、リスト・マッチング処理の不具合修正（主に regex.py）  

### 不具合報告
[kanjize v1.3.0がインストールされるため、kanji2intがエラーになってしまう](https://github.com/Taka710/normalize-japanese-addresses-py/issues/2)