### PR TITLE
fix version of kanjize install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=setuptools.find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
         "requests",
-        "kanjize",
+        "kanjize>=1.4.0",
         "cachetools"
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
0.0.6以前を利用していてアップデートする際に、インストールされているkanjizeが問題になることがあると思うので、バージョンを指定することをご提案します。